### PR TITLE
Prevent Yosys from optimizing LUT4 delays

### DIFF
--- a/ringoscillator.v
+++ b/ringoscillator.v
@@ -32,6 +32,7 @@ module ringoscillator(output wire out);
 
 	// Single LUT delay line. This also takes care that the compiler
 	// (yosys) is not removing this logic path.
+	(* keep *)
 	SB_LUT4 #(
 		.LUT_INIT(16'd2)
 	) buffers (
@@ -58,6 +59,7 @@ module ringoscillator_minimal_delay(output wire out);
 
 	// Single LUT delay line. This also takes care that the compiler
 	// (yosys) is not removing this logic path.
+	(* keep *)
 	SB_LUT4 #(
 		.LUT_INIT(16'd1)
 	) buffers (


### PR DESCRIPTION
Yosys recently enabled `-relut` by default and it is now required to add `(* keep *)` attributes to prevent unwanted optimizations.

See YosysHQ/yosys#1254 for more details.